### PR TITLE
Fix wrong system template path check

### DIFF
--- a/src/main/java/com/edu/asistente_cupos/domain/prompt/PromptBuilderTemplated.java
+++ b/src/main/java/com/edu/asistente_cupos/domain/prompt/PromptBuilderTemplated.java
@@ -48,7 +48,7 @@ public class PromptBuilderTemplated {
   }
 
   private Message systemMessageDesde() {
-    if (userTemplatePath == null)
+    if (systemTemplatePath == null)
       throw new IllegalStateException("Falta el path del template system");
     return new SystemMessage(promptTemplateProvider.leerTemplateComoString(systemTemplatePath));
   }


### PR DESCRIPTION
## Summary
- fix variable checked in `PromptBuilderTemplated.systemMessageDesde`

## Testing
- `gradle test --no-daemon` *(fails: Plugin org.springframework.boot not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843306997cc83319f0810eaa0ffd23d